### PR TITLE
Elegantly handle depth 0 trees in biased fits

### DIFF
--- a/R/pre.R
+++ b/R/pre.R
@@ -439,15 +439,15 @@ pre <- function(formula, data, family = gaussian,
     }
     if (use.grad && tree.unbiased && !use_glmertree) {
       if (!setequal(names(ctree_control()), names(tree.control))) {
-        stop("Argument 'tree.control' should be a list containing named elements", paste(names(ctree_control()), collapse = ', '))
+        stop("Argument 'tree.control' should be a list containing named elements ", paste(names(ctree_control()), collapse = ', '))
       }
     } else if (!use.grad && tree.unbiased) { 
       if (!setequal(names(mob_control()), names(tree.control))) {
-        stop("Argument 'tree.control' should be a list containing named elements", paste(names(mob_control()), collapse = ', '))
+        stop("Argument 'tree.control' should be a list containing named elements ", paste(names(mob_control()), collapse = ', '))
       }
     } else if (!tree.unbiased) {
       if (!setequal(names(rpart.control()), names(tree.control))) {
-        stop("Argument 'tree.control' should be a list containing names elements", paste(names(rpart.control()), collapse = ', '))
+        stop("Argument 'tree.control' should be a list containing names elements ", paste(names(rpart.control()), collapse = ', '))
       }
     }
     if (use.grad) { ## if ctree or rpart are employed:

--- a/R/pre.R
+++ b/R/pre.R
@@ -438,16 +438,16 @@ pre <- function(formula, data, family = gaussian,
       stop("Argument 'tree.control' should be a list of control parameters.")
     }
     if (use.grad && tree.unbiased && !use_glmertree) {
-      if (!all(sort(names(ctree_control())) == sort(names(tree.control)))) {
-        stop("Argument 'tree.control' should be a list containing named elements", names(ctree_control()))
+      if (!setequal(names(ctree_control()), names(tree.control))) {
+        stop("Argument 'tree.control' should be a list containing named elements", paste(names(ctree_control()), collapse = ', '))
       }
     } else if (!use.grad && tree.unbiased) { 
-      if (!all(sort(names(mob_control())) == sort(names(tree.control)))) {
-        stop("Argument 'tree.control' should be a list containing named elements", names(mob_control()))
+      if (!setequal(names(mob_control()), names(tree.control))) {
+        stop("Argument 'tree.control' should be a list containing named elements", paste(names(mob_control()), collapse = ', '))
       }
     } else if (!tree.unbiased) {
-      if(!all(sort(names(rpart.control())) == sort(names(tree.control)))) {
-        stop("Argument 'tree.control' should be a list containing names elements", names(rpart.control()))
+      if (!setequal(names(rpart.control()), names(tree.control))) {
+        stop("Argument 'tree.control' should be a list containing names elements", paste(names(rpart.control()), collapse = ', '))
       }
     }
     if (use.grad) { ## if ctree or rpart are employed:

--- a/R/pre.R
+++ b/R/pre.R
@@ -1313,7 +1313,7 @@ pre_rules <- function(formula, data, weights = rep(1, nrow(data)),
       rules <- gsub(pattern = ",", replacement = "\", \"", x = rules, fixed = TRUE)
       ## add "')" at the end of the string
       rules <- strsplit(x = rules, split = " & ", fixed = TRUE)
-      for (i in 1:length(rules)) {
+      for (i in seq_along(rules)) {
         for (j in names(data)[sapply(data, is.factor)]) {
           if (any(grepl(j, rules[[i]], fixed = TRUE))) {
             rules[[i]][grepl(j, rules[[i]], fixed = TRUE)] <- paste0(

--- a/R/utils.R
+++ b/R/utils.R
@@ -9,10 +9,13 @@ delete_duplicates_complements <- function(
   rulevars <- if(sparse)
     .get_rules_mat_sparse(data, rules) else
       .get_rules_mat_dense(data, rules)
-  colnames(rulevars) <- names(rules) <- paste0("rule", 1:length(rules))
+  rules_to_process <- length(rules) > 0
+  if (rules_to_process) {
+    colnames(rulevars) <- names(rules) <- paste0("rule", 1:length(rules))
+  }
   
   ## Remove duplicate rules
-  if (removeduplicates) {
+  if (removeduplicates && rules_to_process) {
     # Remove rules with identical support
     duplicates <- duplicated(rulevars, MARGIN = 2)
     duplicates.removed <- rules[duplicates]
@@ -23,7 +26,7 @@ delete_duplicates_complements <- function(
     duplicates.removed <- NULL
   
   ## Remove complement rules
-  if (removecomplements) {
+  if (removecomplements && rules_to_process) {
     if (sparse) {
       is_all_binary <- all(rulevars@x %in% 0:1)
       if (!is_all_binary) stop("method not implemented for non-binary rules")
@@ -110,7 +113,7 @@ delete_duplicates_complements <- function(
     complements.removed <- NULL
   }
   
-  rulevars = if (keep_rulevars && length(rules) > 0)
+  rulevars = if (keep_rulevars && rules_to_process)
     rulevars[, names(rules)] else NULL
   
   ## Return results:


### PR DESCRIPTION
Currently, pre() will fail with an out of bounds error if any base tree is of depth 0 with `unbiased=FALSE` (i.e. using rpart to fit trees) and the feature set includes a factor. Here's a reproducible example:

```R
library(pre)
library(partykit)
library(rpart)

airquality_cp <- airquality
# introduce a factor predictor to exercise relevant code path
airquality_cp$noise <- as.factor(rbinom(nrow(airquality_cp), 1, .5))

# test unbiased tree code path, building stumps by imposing an impossible significance level
tree_control <- ctree_control(alpha=1e-10)
airq.ens.unbiased <- pre(Ozone ~ ., data = na.omit(airquality_cp), 
                         tree.control = tree_control)
coef(airq.ens.unbiased$glmnet.fit)
# this works as expected - a linear model is fit with no rules

# test biased tree code path, building stumps by imposing an impossible error reduction threshold
tree_control <- rpart.control(cp = 1.0)
airq.ens.biased <- pre(Ozone ~ ., data = na.omit(airquality_cp), 
                       tree.unbiased = FALSE,
                       tree.control = tree_control)
```
The last call results in:
```
Error in rules[[i]] : subscript out of bounds
```

This PR changes this behavior to pass through the empty list of rules and fit a 0 rule linear model, to match the `unbiased=TRUE` case.
```R
setwd('~/pre')
devtools::load_all()
airq.ens.biased <- pre(Ozone ~ ., data = na.omit(airquality_cp), 
                       tree.unbiased = FALSE,
                       tree.control = tree_control)
coef(airq.ens.biased$glmnet.fit)
```
resulting in:

```
(Intercept) -43.119109
Solar.R       2.318196
Wind        -21.168268
Temp         32.766033
Month         .       
Day           .       
noise1        .       
```
Additionally, these changes improves the error message formatting when an invalid tree.control argument is supplied. From:
```
Error in pre(Ozone ~ ., data = na.omit(airquality_cp), tree.control = rpart.control()) : 
  Argument 'tree.control' should be a list containing named elementscriterionlogmincriterionminsplitminbucketminprobstumpnmaxlookaheadmtrymaxdepthmultiwaysplittrymaxsurrogatenumsurrogatemajoritycaseweightsapplyfunsaveinfobonferroniupdateselectfunsplitfunsvselectfunsvsplitfunteststatsplitstatsplittestpargstesttypenresampletolintersplitMIA
In addition: Warning message:
In sort(names(ctree_control())) == sort(names(tree.control)) :
  longer object length is not a multiple of shorter object length
```
To:
```
Error in pre(Ozone ~ ., data = na.omit(airquality_cp), tree.control = rpart.control()) : 
  Argument 'tree.control' should be a list containing named elements criterion, logmincriterion, minsplit, minbucket, minprob, stump, nmax, lookahead, mtry, maxdepth, multiway, splittry, maxsurrogate, numsurrogate, majority, caseweights, applyfun, saveinfo, bonferroni, update, selectfun, splitfun, svselectfun, svsplitfun, teststat, splitstat, splittest, pargs, testtype, nresample, tol, intersplit, MIA
```